### PR TITLE
Make program wrappers specify allowed modules

### DIFF
--- a/ParProcCo/job_controller.py
+++ b/ParProcCo/job_controller.py
@@ -44,6 +44,7 @@ class JobController:
 
         self.cluster_runner = check_location(get_absolute_path(self.program_wrapper.get_cluster_runner_script()))
         self.cluster_env = self.program_wrapper.get_environment()
+        logging.debug("Cluster environment is %s", self.cluster_env)
         slice_params = self.program_wrapper.create_slices(number_jobs)
 
         sliced_jobs_success = self._run_sliced_jobs(slice_params, jobscript_args, memory, job_name)

--- a/ParProcCo/nxdata_aggregation_mode.py
+++ b/ParProcCo/nxdata_aggregation_mode.py
@@ -12,6 +12,7 @@ class NXdataAggregationMode(SchedulerModeInterface):
         current_script_dir = Path(os.path.realpath(__file__)).parent.parent / "scripts"
         self.program_path = current_script_dir / "nxdata_aggregate"
         self.cores = 1
+        self.allowed_modules = ('python',)
 
     def set_parameters(self, sliced_results: List[Path]) -> None:
         """Overrides SchedulerModeInterface.set_parameters"""

--- a/ParProcCo/passthru_wrapper.py
+++ b/ParProcCo/passthru_wrapper.py
@@ -10,13 +10,12 @@ from .utils import check_jobscript_is_readable, check_location, get_absolute_pat
 import os
 
 class PassThruProcessingMode(SchedulerModeInterface):
-    PPC_Modules = "python/3.9"
 
     def __init__(self):
+        super().__init__()
         self.cores = 6
         current_script_dir = Path(os.path.realpath(__file__)).parent.parent / "scripts"
         self.program_path = current_script_dir / "ppc_cluster_runner"
-        self.environment = {"PPC_MODULES":PassThruProcessingMode.PPC_Modules}
 
     def set_parameters(self, _slice_params: List[slice]) -> None:
         """Overrides SchedulerModeInterface.set_parameters"""

--- a/ParProcCo/scheduler_mode_interface.py
+++ b/ParProcCo/scheduler_mode_interface.py
@@ -10,6 +10,7 @@ class SchedulerModeInterface:
         self.number_jobs: int
         self.cores: int
         self.program_path: Optional[Path]
+        self.allowed_modules: Optional[Tuple[str,...]] = None
 
     def set_parameters(self, sliced_results: List) -> None:
         """Sets parameters for generating jobscript args for use within JobScheduler"""

--- a/ParProcCo/utils.py
+++ b/ParProcCo/utils.py
@@ -62,6 +62,7 @@ class PPCCluster(YAMLObject):
     yaml_tag = "!PPCCluster"
     yaml_loader = SafeLoader
 
+    module: str # module loaded to submit jobs
     default_queue: str # default cluster queue
     user_queues: Optional[Dict[str, List[str]]] = None # specific queues with allowed users
     resources: Optional[Dict[str,str]] = None # job resources
@@ -89,11 +90,13 @@ def load_cfg() -> PPCConfig:
     cluster_help_msg: Please module load blah # Message to display if cluster commands are not available
     clusters:
         cluster_one: !PPCCluster # cluster name 
+            module: foo_cluster_one
             default_queue: basic.q # default cluster queue
             user_queues: # dictionary of queues and list of users 
                 better.q: middle_user1
                 best.q: power_user1, power_user2
         cluster_two: !PPCCluster
+            module: bar_cluster_two
             default_queue: only.q
             resources:
                 cpu_model: arm64

--- a/example/simple_processing_mode.py
+++ b/example/simple_processing_mode.py
@@ -8,12 +8,10 @@ from ParProcCo.utils import slice_to_string, check_jobscript_is_readable, check_
 
 
 class SimpleProcessingMode(SchedulerModeInterface):
-    PPC_Modules = "python/3.9"
-
     def __init__(self, program: Optional[Path] = None) -> None:
         self.program_path: Optional[Path] = program
         self.cores = 1
-        self.environment = {"PPC_MODULES":SimpleProcessingMode.PPC_Modules}
+        self.allowed_modules = ('python',)
 
     def set_parameters(self, slice_params: List[slice]) -> None:
         """Overrides SchedulerModeInterface.set_parameters"""

--- a/scripts/ppc_cluster_runner
+++ b/scripts/ppc_cluster_runner
@@ -4,15 +4,19 @@ if [ -z $MODULESHOME ]; then
 fi
 
 if [ $PPC_MODULES ]; then
+  echo "Loading modules: $PPC_MODULES"
   for m in ${PPC_MODULES//:/ }; do
      module load $m
   done
 fi
 
 if [ $TEST_PPC_DIR ]; then
+  echo "Supplementing PATHs with $TEST_PPC_DIR"
   export PATH=$TEST_PPC_DIR/scripts:$PATH
   export PYTHONPATH=$TEST_PPC_DIR:$PYTHONPATH
 fi
+echo "PATH:   $PATH"
+echo "PyPATH: $PYTHONPATH"
 
 echo "Executing |$@|"
 eval "$@"

--- a/scripts/ppc_cluster_submit
+++ b/scripts/ppc_cluster_submit
@@ -72,6 +72,7 @@ def run_ppc(args: argparse.Namespace, script_args: List) -> None:
             raise ValueError(f'Cannot create Wrapper from {program}_wrapper module') from exc
     else:
         raise ValueError(f'Number of jobs must be one or more, given {args.jobs}')
+    wrapper.set_module(cluster.module)
     wrapper.set_cores(args.cores)
     output = wrapper.get_output(args.output, script_args[1:])
     jc = JobController(wrapper, output, project, cluster_queue, cluster_resources)


### PR DESCRIPTION
Add attributes to mode interface and program wrappers so specific modules can be passed onwards to cluster runner. This removes need to update with new module versions. Add more logging too