### PR TITLE
Specify the correct environment variable `SLURM_PARTITION` in errors

### DIFF
--- a/tests/test_job_controller.py
+++ b/tests/test_job_controller.py
@@ -25,7 +25,7 @@ slurm_rest_url = get_slurm_rest_url()
 gh_testing = slurm_rest_url is None
 
 if not gh_testing and not PARTITION:
-    raise ValueError("Need to define default partition in DEFAULT_SLURM_PARTITION")
+    raise ValueError("Need to define default partition in SLURM_PARTITION")
 
 
 @pytest.mark.skipif(gh_testing, reason="running GitHub workflow")

--- a/tests/test_job_scheduler.py
+++ b/tests/test_job_scheduler.py
@@ -38,7 +38,7 @@ slurm_rest_url = get_slurm_rest_url()
 gh_testing = slurm_rest_url is None
 
 if not gh_testing and not PARTITION:
-    raise ValueError("Need to define default partition in DEFAULT_SLURM_PARTITION")
+    raise ValueError("Need to define default partition in SLURM_PARTITION")
 
 
 def create_js(timeout=timedelta(seconds=20)) -> JobScheduler:


### PR DESCRIPTION
in tests/utils.py:
`PARTITION = os.getenv("SLURM_PARTITION")`

So the error message is incorrect (or the above line is)